### PR TITLE
feature: add dark mode support

### DIFF
--- a/application/src/main/res/values/themes.xml
+++ b/application/src/main/res/values/themes.xml
@@ -6,7 +6,7 @@
 
   <!-- region Theme -->
 
-  <style name="ItemistEvolved.AppTheme" parent="Theme.MaterialComponents.Light.NoActionBar">
+  <style name="ItemistEvolved.AppTheme" parent="Theme.MaterialComponents.DayNight.NoActionBar">
 
     <item name="colorPrimary">@color/colorPrimary</item>
     <item name="colorPrimaryDark">@color/colorPrimaryDark</item>


### PR DESCRIPTION
Fixes #59 

Also, would you be kind to add the `hacktoberfest-accepted` label? Thanks!

Here's some images in dark mode

![image](https://user-images.githubusercontent.com/8679058/137620704-0b4f9d61-c5ec-4472-8b26-659c01b19d05.png)

![image](https://user-images.githubusercontent.com/8679058/137620722-6b3ea67a-9a38-4c9f-8fa8-58474a8512f5.png)